### PR TITLE
Add .gitattributes to recognize Jupyter notebooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python


### PR DESCRIPTION
Adiciona configuração do linguist para tratar arquivo .ipynb  como Python